### PR TITLE
Add void native type hint for compatibility

### DIFF
--- a/tests/EasyDoc/TestCase.php
+++ b/tests/EasyDoc/TestCase.php
@@ -13,7 +13,7 @@ class TestCase extends PHPUnitTestCase
     protected $tempDirectory;
     protected $githubToken;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->githubToken = getenv('GITHUB_TOKEN');
         putenv('GITHUB_TOKEN');
@@ -21,7 +21,7 @@ class TestCase extends PHPUnitTestCase
         $this->tempDirectory = sys_get_temp_dir().'/doc-'.mt_rand(0, 9999999);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->githubToken ? putenv('GITHUB_TOKEN='.$this->githubToken) : putenv('GITHUB_TOKEN');
         $this->removeDirectory($this->tempDirectory);


### PR DESCRIPTION
# Changed log
- To be compatible with PHPUnit fixture methods, using the `:void` type hint for `setUp` and `tearDown` methods.