### PR TITLE
Filter the latest to only use the stable versions

### DIFF
--- a/tests/EasyDoc/Util/PharPublishTest.php
+++ b/tests/EasyDoc/Util/PharPublishTest.php
@@ -67,6 +67,12 @@ class PharPublishTest extends TestCase
                 '1.3.0' => [
                     'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.3.0/library.phar',
                 ],
+                '1.4.0' => [
+                    'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.4.0/library.phar',
+                ],
+                '1.4.1' => [
+                    'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.4.1/library.phar',
+                ],
                 'latest' => [
                     'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.3.0/library.phar',
                 ],
@@ -97,11 +103,11 @@ class PharPublishTest extends TestCase
 
         $this->assertDirectoryImage([
             'download' => [
-                '1.0.19' => [
-                    'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.0.19/library.phar',
+                '1.4.0' => [
+                    'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.4.0/library.phar',
                 ],
-                '1.3.0' => [
-                    'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.3.0/library.phar',
+                '1.4.1' => [
+                    'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.4.1/library.phar',
                 ],
                 'latest' => [
                     'library.phar' => 'PHAR SAMPLE: /web/vendor/library/releases/download/1.3.0/library.phar',
@@ -140,6 +146,16 @@ class PharPublishTest extends TestCase
 
         $this->assertSame(
             [
+                [
+                    $this->tempDirectory."/download/1.4.1/library.phar skipped because it's only 69.0 B while at least 200 kB is expected.\n",
+                    'light_red',
+                    null,
+                ],
+                [
+                    $this->tempDirectory."/download/1.4.0/library.phar skipped because it's only 69.0 B while at least 200 kB is expected.\n",
+                    'light_red',
+                    null,
+                ],
                 [
                     $this->tempDirectory."/download/1.3.0/library.phar skipped because it's only 69.0 B while at least 200 kB is expected.\n",
                     'light_red',
@@ -185,6 +201,16 @@ class PharPublishTest extends TestCase
 
         $this->assertSame(
             [
+                [
+                    $this->tempDirectory."/download/1.4.1/library.phar skipped because it's only 69.0 B while at least 987,654 TB is expected.\n",
+                    'light_red',
+                    null,
+                ],
+                [
+                    $this->tempDirectory."/download/1.4.0/library.phar skipped because it's only 69.0 B while at least 987,654 TB is expected.\n",
+                    'light_red',
+                    null,
+                ],
                 [
                     $this->tempDirectory."/download/1.3.0/library.phar skipped because it's only 69.0 B while at least 987,654 TB is expected.\n",
                     'light_red',

--- a/tests/EasyDoc/Util/github.php
+++ b/tests/EasyDoc/Util/github.php
@@ -10,12 +10,28 @@ if ($_SERVER['REQUEST_URI'] === '/api/vendor/library/releases') {
     echo json_encode([
         [
             'tag_name' => '1.0.0',
+            'draft' => false,
+            'prerelease' => false,
         ],
         [
             'tag_name' => '1.3.0',
+            'draft' => false,
+            'prerelease' => false,
         ],
         [
             'tag_name' => '1.0.19',
+            'draft' => false,
+            'prerelease' => false,
+        ],
+        [
+            'tag_name' => '1.4.0',
+            'draft' => false,
+            'prerelease' => true,
+        ],
+        [
+            'tag_name' => '1.4.1',
+            'draft' => true,
+            'prerelease' => false,
         ],
     ]);
 


### PR DESCRIPTION
This filter out the drafts and prerelease versions for the latest.

See: https://api.github.com/repos/kylekatarnls/php-easy-doc/releases for the json and keys